### PR TITLE
Expand error column in project table

### DIFF
--- a/application/common/models/ProjectBase.php
+++ b/application/common/models/ProjectBase.php
@@ -42,7 +42,8 @@ class ProjectBase extends \yii\db\ActiveRecord
         return [
             [['created', 'updated'], 'safe'],
             [['client_id'], 'integer'],
-            [['status', 'result', 'error', 'user_id', 'group_id', 'app_id', 'project_name', 'language_code'], 'string', 'max' => 255],
+            [['status', 'result', 'user_id', 'group_id', 'app_id', 'project_name', 'language_code'], 'string', 'max' => 255],
+            [['error'], 'string', 'max' => 2083],
             [['url', 'publishing_key'], 'string', 'max' => 1024],
             [['client_id'], 'exist', 'skipOnError' => true, 'targetClass' => Client::className(), 'targetAttribute' => ['client_id' => 'id']],
         ];

--- a/application/console/migrations/m161108_135607_alter_project_error_column.php
+++ b/application/console/migrations/m161108_135607_alter_project_error_column.php
@@ -1,0 +1,18 @@
+<?php
+
+use yii\db\Schema;
+use yii\db\Migration;
+
+class m161108_135607_alter_project_error_column extends Migration
+{
+    public function up()
+    {
+        $this->alterColumn("{{project}}", "error", "varchar(2083) null");
+    }
+
+    public function down()
+    {
+        $this->alterColumn("{{project}}", "error", Schema::TYPE_STRING. " null");
+    }
+
+}


### PR DESCRIPTION
Errors were not being handled properly because the error field was not large enough