### PR TITLE
Change where whats_new.txt is saved

### DIFF
--- a/application/console/views/cron/scripts/scriptureappbuilder/jobs.groovy
+++ b/application/console/views/cron/scripts/scriptureappbuilder/jobs.groovy
@@ -24,6 +24,11 @@ fi
 PUBLISH_DIR="build_data/publish/play-listing"
 if [ -d "$PUBLISH_DIR" ]; then
   cp -r "$PUBLISH_DIR" output
+  find output -name whats_new.txt | while read filename; do
+    DIR=$(dirname "${filename}")
+    mkdir "${DIR}/changelogs"
+    mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt"
+  done
 fi
 mv build_data "${PROJNAME}_data"
 mv build.appDef "${PROJNAME}.appDef"


### PR DESCRIPTION
* There was a change in Google (and Fastlane.Tools Supply script)
  to how whats_new is uploaded.  It is now in:
  changelogs/<version_code>.txt