### PR TITLE
Add target and environment to build and release

### DIFF
--- a/application/common/components/AWSCommon.php
+++ b/application/common/components/AWSCommon.php
@@ -43,6 +43,14 @@ class AWSCommon
         return \Yii::$app->params['codeBuildImage'];
     }
 
+    public static function getBuildScriptPath()
+    {
+        $bucket = str_replace('"', "", AWSCommon::getProjectsBucket());
+        $s3path = "s3://". $bucket .'/default';
+
+        return $s3path;
+
+    }
     public static function getArtifactPath($build, $productionStage)
     {
         $job = $build->job;

--- a/application/common/components/AWSCommon.php
+++ b/application/common/components/AWSCommon.php
@@ -45,8 +45,7 @@ class AWSCommon
 
     public static function getBuildScriptPath()
     {
-        $bucket = str_replace('"', "", AWSCommon::getProjectsBucket());
-        $s3path = "s3://". $bucket .'/default';
+        $s3path = "s3://". AWSCommon::getProjectsBucket() .'/default';
 
         return $s3path;
 

--- a/application/common/models/Build.php
+++ b/application/common/models/Build.php
@@ -177,6 +177,8 @@ class Build extends BuildBase implements Linkable
                     self::ARTIFACT_CLOUD_WATCH => $this->cloudWatch(),
                     self::ARTIFACT_CONSOLE_TEXT => $this->consoleText()];
             },
+            'targets',
+            'environment',
             'created' => function(){
                 return Utils::getIso8601($this->created);
             },

--- a/application/common/models/Build.php
+++ b/application/common/models/Build.php
@@ -86,10 +86,12 @@ class Build extends BuildBase implements Linkable
             self::CHANNEL_PRODUCTION,
         ],
      ];
-    public function createRelease($channel) {
+    public function createRelease($channel, $targets, $environment) {
         $release = new Release();
         $release->build_id = $this->id;
         $release->channel = $channel;
+        $release->targets = $targets;
+        $release->environment = $environment;
         $release->save();
 
         return $release;

--- a/application/common/models/BuildBase.php
+++ b/application/common/models/BuildBase.php
@@ -21,6 +21,8 @@ use Yii;
  * @property string $build_guid
  * @property string $console_text_url
  * @property string $codebuild_url
+ * @property string $targets
+ * @property string $environment
  *
  * @property Job $job
  * @property Release[] $releases
@@ -44,7 +46,7 @@ class BuildBase extends \yii\db\ActiveRecord
             [['job_id'], 'required'],
             [['job_id', 'version_code'], 'integer'],
             [['created', 'updated'], 'safe'],
-            [['status', 'result', 'channel', 'artifact_files', 'build_guid', 'console_text_url', 'codebuild_url'], 'string', 'max' => 255],
+            [['status', 'result', 'channel', 'artifact_files', 'build_guid', 'console_text_url', 'codebuild_url', 'targets', 'environment'], 'string', 'max' => 255],
             [['error', 'artifact_url_base'], 'string', 'max' => 2083],
             [['job_id'], 'exist', 'skipOnError' => true, 'targetClass' => Job::className(), 'targetAttribute' => ['job_id' => 'id']],
         ];
@@ -70,6 +72,8 @@ class BuildBase extends \yii\db\ActiveRecord
             'build_guid' => Yii::t('app', 'Build Guid'),
             'console_text_url' => Yii::t('app', 'Console Text Url'),
             'codebuild_url' => Yii::t('app', 'Codebuild Url'),
+            'targets' => Yii::t('app', 'Targets'),
+            'environment' => Yii::t('app', 'Environment'),
         ];
     }
 

--- a/application/common/models/Job.php
+++ b/application/common/models/Job.php
@@ -115,10 +115,12 @@ class Job extends JobBase implements Linkable
      *
      * @return Build
      */
-    public function createBuild()
+    public function createBuild($targets, $environment)
     {
             $build = new Build();
             $build->job_id = $this->id;
+            $build->targets = $targets;
+            $build->environment = $environment;
             $build->save();
 
             return $build;

--- a/application/common/models/ReleaseBase.php
+++ b/application/common/models/ReleaseBase.php
@@ -21,6 +21,8 @@ use Yii;
  * @property string $build_guid
  * @property string $console_text_url
  * @property string $codebuild_url
+ * @property string $targets
+ * @property string $environment
  *
  * @property Build $build
  */
@@ -43,7 +45,7 @@ class ReleaseBase extends \yii\db\ActiveRecord
             [['build_id', 'channel'], 'required'],
             [['build_id'], 'integer'],
             [['created', 'updated'], 'safe'],
-            [['status', 'result', 'channel', 'defaultLanguage', 'promote_from', 'build_guid', 'console_text_url', 'codebuild_url'], 'string', 'max' => 255],
+            [['status', 'result', 'channel', 'defaultLanguage', 'promote_from', 'build_guid', 'console_text_url', 'codebuild_url', 'targets', 'environment'], 'string', 'max' => 255],
             [['error'], 'string', 'max' => 2083],
             [['title'], 'string', 'max' => 30],
             [['build_id'], 'exist', 'skipOnError' => true, 'targetClass' => Build::className(), 'targetAttribute' => ['build_id' => 'id']],
@@ -70,6 +72,8 @@ class ReleaseBase extends \yii\db\ActiveRecord
             'build_guid' => Yii::t('app', 'Build Guid'),
             'console_text_url' => Yii::t('app', 'Console Text Url'),
             'codebuild_url' => Yii::t('app', 'Codebuild Url'),
+            'targets' => Yii::t('app', 'Targets'),
+            'environment' => Yii::t('app', 'Environment'),
         ];
     }
 

--- a/application/console/components/AwsStartupAction.php
+++ b/application/console/components/AwsStartupAction.php
@@ -13,7 +13,6 @@ use common\helpers\Utils;
 
 class AwsStartupAction extends ActionCommon
 {
-    private $s3;
     /**
      * This method checks to see if the code build projects for build and publish exist
      * and builds them if they don't
@@ -74,25 +73,6 @@ class AwsStartupAction extends ActionCommon
             $logger->appbuilderExceptionLog($logException, $e);
         }
     }
-    private function copyDefaultProjectFolder($logger)
-    {
-        try {
-            $prefix = Utils::getPrefix();
-            echo "[$prefix] AwsStartupAction: copyDefaultProjectFolder" . PHP_EOL;
-            $s3 = new S3();
-            $sourceFolder = '/data/console/views/cron/scripts/project_default';
-            $bucket = S3::getArtifactsBucket();
-            $s3->uploadFolder($sourceFolder, $bucket);
-            echo "  Copy completed" . PHP_EOL;
-        } catch (\Exception $e) {
-            $prefix = Utils::getPrefix();
-            echo "[$prefix] copyDefaultProjectFolder: Exception:" . PHP_EOL . (string)$e . PHP_EOL;
-            $logException = [
-                'problem' => 'Failed to copy project default folder'
-            ];
-            $logger->appbuilderExceptionLog($logException, $e);
-        }
-    }
     private function createProject($projectName, $cache, $source, $logger)
     {
         try {
@@ -119,25 +99,37 @@ class AwsStartupAction extends ActionCommon
             $logger->appbuilderExceptionLog($logException, $e);
         }
     }
+    private function copyDefaultProjectFolder($logger)
+    {
+        $prefix = Utils::getPrefix();
+        echo "[$prefix] AwsStartupAction: copyDefaultProjectFolder" . PHP_EOL;
+        $sourceFolder = '/data/console/views/cron/scripts/project_default';
+        $bucket = S3::getArtifactsBucket();
+        $this->copyFolder($logger, $sourceFolder, $bucket);
+    }
     private function copyBuildScriptFolder($logger)
+    {
+        $prefix = Utils::getPrefix();
+        echo "[$prefix] AwsStartupAction: copyBuildScriptFolder" . PHP_EOL;
+        $sourceFolder = '/data/console/views/cron/scripts/upload';
+        $bucket = S3::getProjectsBucket();
+        $this->copyFolder($logger, $sourceFolder, $bucket);
+    }
+    private function copyFolder($logger, $sourceFolder, $bucket)
     {
         try {
             $prefix = Utils::getPrefix();
-            echo "[$prefix] AwsStartupAction: copyBuildScriptFolder" . PHP_EOL;
+            echo "[$prefix] AwsStartupAction: copyFolder" . PHP_EOL;
             $s3 = new S3();
-            $currentDir = getcwd();
-            $sourceFolder = '/data/console/views/cron/scripts/upload';
-            $bucket = str_replace('"', "", S3::getProjectsBucket());
             $s3->uploadFolder($sourceFolder, $bucket);
             echo "  Copy completed" . PHP_EOL;
         } catch (\Exception $e) {
             $prefix = Utils::getPrefix();
-            echo "[$prefix] createCodeBuildProject: Exception:" . PHP_EOL . (string)$e . PHP_EOL;
+            echo "[$prefix] copyFolder: Exception:" . PHP_EOL . (string)$e . PHP_EOL;
             $logException = [
-                'problem' => 'Failed to copy build script folder'
+                'problem' => 'Failed to copy folder'
             ];
             $logger->appbuilderExceptionLog($logException, $e);
         }
-
     }
 }

--- a/application/console/components/ManageBuildsAction.php
+++ b/application/console/components/ManageBuildsAction.php
@@ -101,7 +101,7 @@ class ManageBuildsAction extends ActionCommon
                 ]);
                 // Start the build
                 $codeBuild = new CodeBuild();
-                $versionCode = $this->getNextVersionCode($job, $build);
+                $versionCode = $this->getVersionCode($job, $build) + 1;
                 $lastBuildGuid = $codeBuild->startBuild($repoUrl, (string)$commitId, $build, (string) $script, (string)$versionCode, $codeCommitProject);
                 if (!is_null($lastBuildGuid)){
                     $build->build_guid = $lastBuildGuid;
@@ -114,11 +114,11 @@ class ManageBuildsAction extends ActionCommon
            }
            else {
                 $script = $this->cronController->renderPartial("scripts/appbuilders_s3_build", [
-                    ]);
+                   ]);
                 // Start the build
                 $codeBuild = new CodeBuild();
                 $commitId = ""; // TODO: Remove when git is removed
-                $versionCode = $this->getNextVersionCode($job, $build);
+                $versionCode = $this->getVersionCode($job, $build);
                 $lastBuildGuid = $codeBuild->startBuild($gitUrl, (string)$commitId, $build, (string) $script, (string)$versionCode, $codeCommitProject);
                 if (!is_null($lastBuildGuid)){
                     $build->build_guid = $lastBuildGuid;
@@ -203,7 +203,7 @@ class ManageBuildsAction extends ActionCommon
         }
     }
 
-    private function getNextVersionCode($job, $build) {
+    private function getVersionCode($job, $build) {
         $id = $job->id;
         $retval = $job->existing_version_code;
         foreach (Build::find()->where([
@@ -214,7 +214,6 @@ class ManageBuildsAction extends ActionCommon
                     $retval = $build->version_code;
                 }
         }
-        $retval = $retval + 1;
         return $retval;
     }
     private function failBuild($build) {

--- a/application/console/components/ManageReleasesAction.php
+++ b/application/console/components/ManageReleasesAction.php
@@ -108,8 +108,6 @@ class ManageReleasesAction extends ActionCommon
             $script = $this->cronController->renderPartial("scripts/appbuilders_publish", [
                 ]);
 
-            echo $script;
-            
             // Start the build
             $codeBuild = new CodeBuild();
             $lastBuildGuid = $codeBuild->startRelease($release, (string) $script);

--- a/application/console/migrations/m190308_210456_add_target_env_to_build.php
+++ b/application/console/migrations/m190308_210456_add_target_env_to_build.php
@@ -1,0 +1,23 @@
+<?php
+
+use yii\db\Schema;
+use yii\db\Migration;
+
+/**
+ * Class m190308_210456_add_target_env_to_build
+ */
+class m190308_210456_add_target_env_to_build extends Migration
+{
+    public function up()
+    {
+        $this->addColumn("{{build}}", "targets", Schema::TYPE_STRING . " null");
+        $this->addColumn("{{build}}", "environment", Schema::TYPE_STRING . " null");
+    }
+
+    public function down()
+    {
+        $this->dropColumn("{{build}}", "targets");
+        $this->dropColumn("{{build}}", "environment");
+    }
+
+}

--- a/application/console/migrations/m190311_200559_add_target_env_to_release.php
+++ b/application/console/migrations/m190311_200559_add_target_env_to_release.php
@@ -1,0 +1,22 @@
+<?php
+
+use yii\db\Schema;
+use yii\db\Migration;
+
+/**
+ * Class m190311_200559_add_target_env_to_release
+ */
+class m190311_200559_add_target_env_to_release extends Migration
+{
+    public function up()
+    {
+        $this->addColumn("{{release}}", "targets", Schema::TYPE_STRING . " null");
+        $this->addColumn("{{release}}", "environment", Schema::TYPE_STRING . " null");
+    }
+
+    public function down()
+    {
+        $this->dropColumn("{{release}}", "targets");
+        $this->dropColumn("{{release}}", "environment");
+    }
+}

--- a/application/console/views/cron/scripts/appbuilders_publish.php
+++ b/application/console/views/cron/scripts/appbuilders_publish.php
@@ -15,7 +15,10 @@ env:
     "ARTIFACTS_S3_DIR" : "s3://dem-aps-artifacts/dem/jobs/build_scriptureappbuilder_1/3"
     "SECRETS_DIR" : "/secrets"
     "ARTIFACTS_DIR" : "/artifacts"
-    
+    "SCRIPT_DIR"  : "/script"
+    "SCRIPT_S3" : "s3://s3url/default"
+    "TARGETS" : ""
+
 phases:
   install:
     commands:
@@ -24,15 +27,15 @@ phases:
       - SECRETS_S3="s3://${SECRETS_BUCKET}/jenkins/publish/google_play_store/${PUBLISHER}"
       - mkdir "${SECRETS_DIR}"
       - mkdir "${ARTIFACTS_DIR}"
+      - mkdir "${SCRIPT_DIR}"
+      - echo "${SCRIPT_S3}"
       - /root/.local/bin/aws s3 sync "${SECRETS_S3}" "${SECRETS_DIR}"
       - /root/.local/bin/aws s3 sync "${ARTIFACTS_S3_DIR}" "${ARTIFACTS_DIR}"
+      - /root/.local/bin/aws s3 sync "${SCRIPT_S3}" "${SCRIPT_DIR}"
       - ls -l "${ARTIFACTS_DIR}"
   build:
     commands:
-      - PAJ="${SECRETS_DIR}/playstore_api.json"
-      - cd $ARTIFACTS_DIR
-      - set +x
-      - if [ -z "$PROMOTE_FROM" ]; then	fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $CHANNEL -m play-listing; else fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $PROMOTE_FROM --track_promote_to $CHANNEL -m play-listing; fi
+      - TARGETS="${TARGETS}" bash ${SCRIPT_DIR}/publish.sh
   #post_build:
     #commands:
 

--- a/application/console/views/cron/scripts/appbuilders_s3_build.php
+++ b/application/console/views/cron/scripts/appbuilders_s3_build.php
@@ -15,7 +15,10 @@ env:
     "SECRETS_BUCKET": "sil-prd-aps-secrets"
     "SECRETS_DIR" : "/secrets"
     "PROJECT_DIR" : "/project"
+    "SCRIPT_DIR"  : "/script"
     "PROJECT_S3" : "s3://s3url"
+    "SCRIPT_S3" : "s3://s3url/default"
+    "TARGETS" : ""
     
 phases:
   install:
@@ -27,43 +30,18 @@ phases:
       - mkdir "${SECRETS_DIR}"
       - mkdir "${OUTPUT_DIR}"
       - mkdir "${PROJECT_DIR}"
+      - mkdir "${SCRIPT_DIR}"
       - echo "PROJECT_S3=${PROJECT_S3}"
       - /root/.local/bin/aws s3 sync "${PROJECT_S3}" "${PROJECT_DIR}"
       - /root/.local/bin/aws s3 sync "${SECRETS_S3}" "${SECRETS_DIR}"
+      - /root/.local/bin/aws s3 sync "${SCRIPT_S3}" "${SCRIPT_DIR}"
       - export KSP=$(cat "${SECRETS_DIR}/ksp.txt")
       - export KA=$(cat "${SECRETS_DIR}/ka.txt")
       - export KAP=$(cat "${SECRETS_DIR}/kap.txt")
       - export GRADLE_OPTS="-Dorg.gradle.daemon=false"
   build:
     commands:
-      - KS="${SECRETS_DIR}/${PUBLISHER}.keystore"
-      - echo "BUILD_NUMBER=${BUILD_NUMBER}"
-      - echo "VERSION_CODE=${VERSION_CODE}"
-      - OUTPUT_DIR="/${BUILD_NUMBER}"
-      - cd $PROJECT_DIR
-      - PROJNAME=$(basename *.appDef .appDef)
-      - mv "${PROJNAME}.appDef" build.appDef
-      - mv "${PROJNAME}_data" build_data
-      - APPDEF_VERSION=$(grep "version code=" build.appDef|awk -F"\"" '{print $2}')
-      - echo "APPDEF_VERSION=${APPDEF_VERSION}"
-      - if [ "$APPDEF_VERSION" -ge "$VERSION_CODE" ]; then VERSION_CODE=$((APPDEF_VERSION+1)); fi
-      - VERSION_NAME=$(dpkg -s scripture-app-builder | grep 'Version' | awk -F '[ +]' '{print $2}')
-      - $APP_BUILDER_SCRIPT_PATH -load build.appDef -no-save -build -ks $KS -ksp $KSP -ka $KA -kap $KAP -fp apk.output=$OUTPUT_DIR -vc $VERSION_CODE -vn $VERSION_NAME -ft share-app-link=true
-      - echo $(awk -F '[<>]' '/package/{print $3}' build.appDef) > $OUTPUT_DIR/package_name.txt
-      - echo $VERSION_CODE > $OUTPUT_DIR/version_code.txt
-      - "echo \"{ \\\"version\\\" : \\\"${VERSION_NAME}.${VERSION_CODE}\\\", \\\"versionName\\\" : \\\"${VERSION_NAME}\\\", \\\"versionCode\\\" : \\\"${VERSION_CODE}\\\" } \" > $OUTPUT_DIR/version.json"
-      - if [ -f "build_data/about/about.txt" ]; then cp build_data/about/about.txt $OUTPUT_DIR/; fi
-      - PUBLISH_DIR="build_data/publish"
-      - PLAY_LISTING_DIR="${PUBLISH_DIR}/play-listing"
-      - LIST_DIR="${PLAY_LISTING_DIR}/"
-      - MANIFEST_FILE="manifest.txt"
-      - if [ -f $LIST_DIR$MANIFEST_FILE ]; then rm $LIST_DIR$MANIFEST_FILE; fi;
-      - FILE_LIST=$(find $PLAY_LISTING_DIR -type f -print)
-      - for f in $FILE_LIST; do fn=${f#*"$PLAY_LISTING_DIR/"}; echo $fn >> $OUTPUT_DIR/$MANIFEST_FILE; done
-      - if [ -d "$PLAY_LISTING_DIR" ]; then cp -r "$PLAY_LISTING_DIR" $OUTPUT_DIR; find $OUTPUT_DIR -name whats_new.txt | while read filename; do DIR=$(dirname "${filename}"); cp "$filename" $OUTPUT_DIR; mkdir "${DIR}/changelogs"; mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt"; done; fi
-      - mv build_data "${PROJNAME}_data"
-      - mv build.appDef "${PROJNAME}.appDef"
-      #- if [ "$CODEBUILD_BUILD_SUCCEEDING" -gt "0" ]; then git remote -v; git tag $VERSION_CODE; git push origin $VERSION_CODE; fi
+      - TARGETS="${TARGETS}" bash ${SCRIPT_DIR}/build.sh 
   #post_build:
     #commands:
 

--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -2,8 +2,8 @@
 
 build_apk() {
   echo "Build APK"
-  cd $PROJECT_DIR
-  PROJNAME=$(basename *.appDef .appDef)
+  cd "$PROJECT_DIR" || exit 1
+  PROJNAME=$(basename -- *.appDef .appDef)
   mv "${PROJNAME}.appDef" build.appDef
   mv "${PROJNAME}_data" build_data
   APPDEF_VERSION=$(grep "version code=" build.appDef|awk -F"\"" '{print $2}')
@@ -15,9 +15,9 @@ build_apk() {
   echo "APPDEF_VERSION=${APPDEF_VERSION}"
   echo "OUTPUT_DIR=${OUTPUT_DIR}"
   KS="${SECRETS_DIR}/${PUBLISHER}.keystore"
-  cd $PROJECT_DIR
+  cd "$PROJECT_DIR" || exit 1
   VERSION_NAME=$(dpkg -s scripture-app-builder | grep 'Version' | awk -F '[ +]' '{print $2}')
-  $APP_BUILDER_SCRIPT_PATH -load build.appDef -no-save -build -ks $KS -ksp $KSP -ka $KA -kap $KAP -fp apk.output=$OUTPUT_DIR -vc $VERSION_CODE -vn $VERSION_NAME -ft share-app-link=true
+  $APP_BUILDER_SCRIPT_PATH -load build.appDef -no-save -build -ks "$KS" -ksp "$KSP" -ka "$KA" -kap "$KAP" -fp apk.output="$OUTPUT_DIR" -vc "$VERSION_CODE" -vn "$VERSION_NAME" -ft share-app-link=true
 }
 
 build_play_listing() {
@@ -26,49 +26,54 @@ build_play_listing() {
   echo "VERSION_CODE=${VERSION_CODE}"
   echo "APPDEF_VERSION=${APPDEF_VERSION}"
   echo "OUTPUT_DIR=${OUTPUT_DIR}"
-  cd $PROJECT_DIR
-  PROJNAME=$(basename *.appDef .appDef)
+  cd "$PROJECT_DIR" || exit 1
+  PROJNAME=$(basename -- *.appDef .appDef)
   if [ -f "${PROJNAME}.appDef" ]; then
     echo "Moving ${PROJNAME}.appDef and ${PROJNAME}_data"
     mv "${PROJNAME}.appDef" build.appDef
     mv "${PROJNAME}_data" build_data
   fi
-  echo $(awk -F '[<>]' '/package/{print $3}' build.appDef) > $OUTPUT_DIR/package_name.txt
-  echo $VERSION_CODE > $OUTPUT_DIR/version_code.txt
-  echo "{ \"version\" : \"${VERSION_NAME}.${VERSION_CODE}\", \"versionName\" : \"${VERSION_NAME}\", \"versionCode\" : \"${VERSION_CODE}\" } " > $OUTPUT_DIR/version.json
+  awk -F '[<>]' '/package/{print $3}' build.appDef > "$OUTPUT_DIR"/package_name.txt
+  echo $VERSION_CODE > "$OUTPUT_DIR"/version_code.txt
+  echo "{ \"version\" : \"${VERSION_NAME}.${VERSION_CODE}\", \"versionName\" : \"${VERSION_NAME}\", \"versionCode\" : \"${VERSION_CODE}\" } " > "$OUTPUT_DIR"/version.json
   if [ -f "build_data/about/about.txt" ]; then
-    cp build_data/about/about.txt $OUTPUT_DIR/;
+    cp build_data/about/about.txt "$OUTPUT_DIR"/
   fi
   PUBLISH_DIR="build_data/publish"
   PLAY_LISTING_DIR="${PUBLISH_DIR}/play-listing"
   LIST_DIR="${PLAY_LISTING_DIR}/"
   MANIFEST_FILE="manifest.txt"
-  if [ -f $LIST_DIR$MANIFEST_FILE ];
-    then rm $LIST_DIR$MANIFEST_FILE;
+  if [ -f $LIST_DIR$MANIFEST_FILE ]; then
+    rm $LIST_DIR$MANIFEST_FILE
   fi
   FILE_LIST=$(find $PLAY_LISTING_DIR -type f -print)
-  for f in $FILE_LIST; do fn=${f#*"$PLAY_LISTING_DIR/"};
-    echo $fn >> $OUTPUT_DIR/$MANIFEST_FILE;
+  for f in $FILE_LIST
+  do 
+    fn=${f#*"$PLAY_LISTING_DIR/"}
+    echo "$fn" >> "$OUTPUT_DIR"/$MANIFEST_FILE
   done
   if [ -d "$PLAY_LISTING_DIR" ]; then
-    cp -r "$PLAY_LISTING_DIR" $OUTPUT_DIR;
-    find $OUTPUT_DIR -name whats_new.txt | while read filename; do DIR=$(dirname "${filename}");
-      cp "$filename" $OUTPUT_DIR; mkdir "${DIR}/changelogs";
-      mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt";
-    done;
+    cp -r "$PLAY_LISTING_DIR" "$OUTPUT_DIR"
+    find "$OUTPUT_DIR" -name whats_new.txt | while read -r filename
+    do 
+      DIR=$(dirname "${filename}")
+      cp "$filename" "$OUTPUT_DIR"
+      mkdir "${DIR}/changelogs"
+      mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt"
+    done
   fi
 }
 
 build_gradle() {
   echo "Gradle $1"
   if [ -f "${PROJECT_DIR}/build.gradle" ]; then
-    pushd $PROJECT_DIR
-    gradle $1
-    popd
+    pushd "$PROJECT_DIR" || exit 1
+    gradle "$1"
+    popd || exit 1
   elif [ -f "${SCRIPT_DIR}/build.gradle" ]; then
-    pushd $SCRIPT_DIR
-    gradle $1
-    popd
+    pushd "$SCRIPT_DIR" || exit 1
+    gradle "$1"
+    popd || exit 1
   fi
 }
 
@@ -79,6 +84,6 @@ do
   case "$target" in
     "apk") build_apk ;;
     "play-listing") build_play_listing ;;
-    *) build_gradle $target ;;
+    *) build_gradle "$target" ;;
   esac
 done

--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+build_apk() {
+  echo "Build APK"
+  cd $PROJECT_DIR
+  PROJNAME=$(basename *.appDef .appDef)
+  mv "${PROJNAME}.appDef" build.appDef
+  mv "${PROJNAME}_data" build_data
+  APPDEF_VERSION=$(grep "version code=" build.appDef|awk -F"\"" '{print $2}')
+  echo "APPDEF_VERSION=${APPDEF_VERSION}"
+  if [ "$APPDEF_VERSION" -gt "$VERSION_CODE" ]; then VERSION_CODE=$((APPDEF_VERSION)); fi
+  VERSION_CODE=$((VERSION_CODE + 1))
+  echo "BUILD_NUMBER=${BUILD_NUMBER}"
+  echo "VERSION_CODE=${VERSION_CODE}"
+  echo "APPDEF_VERSION=${APPDEF_VERSION}"
+  echo "OUTPUT_DIR=${OUTPUT_DIR}"
+  KS="${SECRETS_DIR}/${PUBLISHER}.keystore"
+  cd $PROJECT_DIR
+  VERSION_NAME=$(dpkg -s scripture-app-builder | grep 'Version' | awk -F '[ +]' '{print $2}')
+  $APP_BUILDER_SCRIPT_PATH -load build.appDef -no-save -build -ks $KS -ksp $KSP -ka $KA -kap $KAP -fp apk.output=$OUTPUT_DIR -vc $VERSION_CODE -vn $VERSION_NAME -ft share-app-link=true
+}
+
+build_play_listing() {
+  echo "Build play listing"
+  echo "BUILD_NUMBER=${BUILD_NUMBER}"
+  echo "VERSION_CODE=${VERSION_CODE}"
+  echo "APPDEF_VERSION=${APPDEF_VERSION}"
+  echo "OUTPUT_DIR=${OUTPUT_DIR}"
+  cd $PROJECT_DIR
+  PROJNAME=$(basename *.appDef .appDef)
+  if [ -f "${PROJNAME}.appDef" ]; then
+    echo "Moving ${PROJNAME}.appDef and ${PROJNAME}_data"
+    mv "${PROJNAME}.appDef" build.appDef
+    mv "${PROJNAME}_data" build_data
+  fi
+  echo $(awk -F '[<>]' '/package/{print $3}' build.appDef) > $OUTPUT_DIR/package_name.txt
+  echo $VERSION_CODE > $OUTPUT_DIR/version_code.txt
+  echo "{ \"version\" : \"${VERSION_NAME}.${VERSION_CODE}\", \"versionName\" : \"${VERSION_NAME}\", \"versionCode\" : \"${VERSION_CODE}\" } " > $OUTPUT_DIR/version.json
+  if [ -f "build_data/about/about.txt" ]; then cp build_data/about/about.txt $OUTPUT_DIR/; fi
+  PUBLISH_DIR="build_data/publish"
+  PLAY_LISTING_DIR="${PUBLISH_DIR}/play-listing"
+  LIST_DIR="${PLAY_LISTING_DIR}/"
+  MANIFEST_FILE="manifest.txt"
+  if [ -f $LIST_DIR$MANIFEST_FILE ]; then rm $LIST_DIR$MANIFEST_FILE; fi;
+  FILE_LIST=$(find $PLAY_LISTING_DIR -type f -print)
+  for f in $FILE_LIST; do fn=${f#*"$PLAY_LISTING_DIR/"}; echo $fn >> $OUTPUT_DIR/$MANIFEST_FILE; done
+  if [ -d "$PLAY_LISTING_DIR" ]; then cp -r "$PLAY_LISTING_DIR" $OUTPUT_DIR; find $OUTPUT_DIR -name whats_new.txt | while read filename; do DIR=$(dirname "${filename}"); cp "$filename" $OUTPUT_DIR; mkdir "${DIR}/changelogs"; mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt"; done; fi
+}
+
+build_gradle() {
+  echo "Gradle $1"
+  if [ -f "${PROJECT_DIR}/build.gradle" ]; then
+    pushd $PROJECT_DIR
+    gradle $1
+    popd
+  elif [ -f "${SCRIPT_DIR}/build.gradle" ]; then
+    pushd $SCRIPT_DIR
+    gradle $1
+    popd
+  fi
+}
+
+echo "TARGETS: $TARGETS"
+env
+for target in $TARGETS
+do
+  case "$target" in
+    "apk") build_apk ;;
+    "play-listing") build_play_listing ;;
+    *) build_gradle $target ;;
+  esac
+done

--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -36,15 +36,27 @@ build_play_listing() {
   echo $(awk -F '[<>]' '/package/{print $3}' build.appDef) > $OUTPUT_DIR/package_name.txt
   echo $VERSION_CODE > $OUTPUT_DIR/version_code.txt
   echo "{ \"version\" : \"${VERSION_NAME}.${VERSION_CODE}\", \"versionName\" : \"${VERSION_NAME}\", \"versionCode\" : \"${VERSION_CODE}\" } " > $OUTPUT_DIR/version.json
-  if [ -f "build_data/about/about.txt" ]; then cp build_data/about/about.txt $OUTPUT_DIR/; fi
+  if [ -f "build_data/about/about.txt" ]; then
+    cp build_data/about/about.txt $OUTPUT_DIR/;
+  fi
   PUBLISH_DIR="build_data/publish"
   PLAY_LISTING_DIR="${PUBLISH_DIR}/play-listing"
   LIST_DIR="${PLAY_LISTING_DIR}/"
   MANIFEST_FILE="manifest.txt"
-  if [ -f $LIST_DIR$MANIFEST_FILE ]; then rm $LIST_DIR$MANIFEST_FILE; fi;
+  if [ -f $LIST_DIR$MANIFEST_FILE ];
+    then rm $LIST_DIR$MANIFEST_FILE;
+  fi
   FILE_LIST=$(find $PLAY_LISTING_DIR -type f -print)
-  for f in $FILE_LIST; do fn=${f#*"$PLAY_LISTING_DIR/"}; echo $fn >> $OUTPUT_DIR/$MANIFEST_FILE; done
-  if [ -d "$PLAY_LISTING_DIR" ]; then cp -r "$PLAY_LISTING_DIR" $OUTPUT_DIR; find $OUTPUT_DIR -name whats_new.txt | while read filename; do DIR=$(dirname "${filename}"); cp "$filename" $OUTPUT_DIR; mkdir "${DIR}/changelogs"; mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt"; done; fi
+  for f in $FILE_LIST; do fn=${f#*"$PLAY_LISTING_DIR/"};
+    echo $fn >> $OUTPUT_DIR/$MANIFEST_FILE;
+  done
+  if [ -d "$PLAY_LISTING_DIR" ]; then
+    cp -r "$PLAY_LISTING_DIR" $OUTPUT_DIR;
+    find $OUTPUT_DIR -name whats_new.txt | while read filename; do DIR=$(dirname "${filename}");
+      cp "$filename" $OUTPUT_DIR; mkdir "${DIR}/changelogs";
+      mv "$filename" "${DIR}/changelogs/${VERSION_CODE}.txt";
+    done;
+  fi
 }
 
 build_gradle() {

--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+google_play() {
+  PAJ="${SECRETS_DIR}/playstore_api.json"
+  cd $ARTIFACTS_DIR
+  set +x
+  if [ -z "$PROMOTE_FROM" ]; then	fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $CHANNEL -m play-listing; else fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $PROMOTE_FROM --track_promote_to $CHANNEL -m play-listing; fi
+}
+publish_gradle() {
+  echo "Gradle $1"
+  if [ -f "${PROJECT_DIR}/publish.gradle" ]; then
+    pushd $PROJECT_DIR
+    gradle $1
+    popd
+  elif [ -f "${SCRIPT_DIR}/publish.gradle" ]; then
+    pushd $SCRIPT_DIR
+    gradle $1
+    popd
+  fi
+}
+
+echo "TARGETS: $TARGETS"
+env
+for target in $TARGETS
+do
+  case "$target" in
+    "google-play") google_play ;;
+    *) publish_gradle $target ;;
+  esac
+done

--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -4,7 +4,11 @@ google_play() {
   PAJ="${SECRETS_DIR}/playstore_api.json"
   cd $ARTIFACTS_DIR
   set +x
-  if [ -z "$PROMOTE_FROM" ]; then	fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $CHANNEL -m play-listing; else fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $PROMOTE_FROM --track_promote_to $CHANNEL -m play-listing; fi
+  if [ -z "$PROMOTE_FROM" ]; then
+    fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $CHANNEL -m play-listing;
+  else
+    fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $PROMOTE_FROM --track_promote_to $CHANNEL -m play-listing;
+  fi
 }
 publish_gradle() {
   echo "Gradle $1"

--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -2,24 +2,24 @@
 
 google_play() {
   PAJ="${SECRETS_DIR}/playstore_api.json"
-  cd $ARTIFACTS_DIR
+  cd "$ARTIFACTS_DIR" || exit 1
   set +x
   if [ -z "$PROMOTE_FROM" ]; then
-    fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $CHANNEL -m play-listing;
+    fastlane supply -j "$PAJ" -b ./*.apk -p "$(cat package_name.txt)" --track "$CHANNEL" -m play-listing
   else
-    fastlane supply -j $PAJ -b *.apk -p $(cat package_name.txt) --track $PROMOTE_FROM --track_promote_to $CHANNEL -m play-listing;
+    fastlane supply -j "$PAJ" -b ./*.apk -p "$(cat package_name.txt)" --track "$PROMOTE_FROM" --track_promote_to "$CHANNEL" -m play-listing
   fi
 }
 publish_gradle() {
   echo "Gradle $1"
   if [ -f "${PROJECT_DIR}/publish.gradle" ]; then
-    pushd $PROJECT_DIR
-    gradle $1
-    popd
+    pushd "$PROJECT_DIR" || exit 1
+    gradle "$1"
+    popd || exit 1
   elif [ -f "${SCRIPT_DIR}/publish.gradle" ]; then
-    pushd $SCRIPT_DIR
-    gradle $1
-    popd
+    pushd "$SCRIPT_DIR" || exit 1
+    gradle "$1"
+    popd || exit 1
   fi
 }
 
@@ -29,6 +29,6 @@ for target in $TARGETS
 do
   case "$target" in
     "google-play") google_play ;;
-    *) publish_gradle $target ;;
+    *) publish_gradle "$target" ;;
   esac
 done

--- a/application/frontend/components/JobControllerUtils.php
+++ b/application/frontend/components/JobControllerUtils.php
@@ -27,7 +27,7 @@ class JobControllerUtils
         }
         return $job;
     }
-    public function publishBuild($id, $build_id, $channel, $title, $defaultLanguage) {
+    public function publishBuild($id, $build_id, $channel, $title, $defaultLanguage, $targets, $environment) {
         $this->validateJob($id);
         $runningRelease = Release::findOne([
             'build_id' => $build_id,
@@ -47,7 +47,8 @@ class JobControllerUtils
         $version_code = $build->version_code;
 
         $verify_result = $this->verifyChannel($id, $channel, $version_code);
-        $release = $build->createRelease($channel);
+        $environmentString = json_encode($environment);
+        $release = $build->createRelease($channel, $targets, $environmentString);
         $release->title = $title;
         $release->defaultLanguage = $defaultLanguage;
         $release->promote_from = $verify_result;

--- a/application/frontend/controllers/JobController.php
+++ b/application/frontend/controllers/JobController.php
@@ -73,11 +73,13 @@ class JobController extends ActiveController
        if (!$job){
            throw new NotFoundHttpException("Job $id not found", 1443810472);
        }
-       $build = $job->createBuild();
+       $targets = \Yii::$app->request->getBodyParam('targets', null);
+       $environment = \Yii::$app->request->getBodyParam('environment', null);
+       $environmentString = json_encode($environment);
+       $build = $job->createBuild($targets, $environmentString);
        if (!$build){
            throw new ServerErrorHttpException("Could not create Build for Job $id", 1443810508);
        }
-
        return $build;
     }
     public function actionDeleteBuild($id, $build_id) {

--- a/application/frontend/controllers/JobController.php
+++ b/application/frontend/controllers/JobController.php
@@ -94,7 +94,9 @@ class JobController extends ActiveController
         $channel = \Yii::$app->request->getBodyParam('channel', null);
         $title = \Yii::$app->request->getBodyParam('title', null);
         $defaultLanguage = \Yii::$app->request->getBodyParam('defaultLanguage', null);
-        $release = $this->jcUtils->publishBuild($id, $build_id, $channel, $title, $defaultLanguage);
+        $targets = \Yii::$app->request->getBodyParam('targets', null);
+        $environment = \Yii::$app->request->getBodyParam('environment', null);
+         $release = $this->jcUtils->publishBuild($id, $build_id, $channel, $title, $defaultLanguage, $targets, $environment);
         return $release;
     }
 

--- a/application/frontend/views/build-admin/_form.php
+++ b/application/frontend/views/build-admin/_form.php
@@ -34,6 +34,10 @@ use yii\widgets\ActiveForm;
 
     <?= $form->field($model, 'version_code')->textInput() ?>
 
+    <?= $form->field($model, 'targets')->textInput() ?>
+
+    <?= $form->field($model, 'environment')->textInput() ?>
+
     <div class="form-group">
         <?= Html::submitButton($model->isNewRecord ? 'Create' : 'Update', ['class' => $model->isNewRecord ? 'btn btn-success' : 'btn btn-primary']) ?>
     </div>

--- a/application/frontend/views/build-admin/view.php
+++ b/application/frontend/views/build-admin/view.php
@@ -64,6 +64,8 @@ $this->params['breadcrumbs'][] = $this->title;
             'updated',
             'channel',
             'version_code',
+            'targets',
+            'environment'
         ],
     ]) ?>
 

--- a/application/frontend/views/release-admin/_form.php
+++ b/application/frontend/views/release-admin/_form.php
@@ -34,6 +34,10 @@ use yii\widgets\ActiveForm;
 
     <?= $form->field($model, 'promote_from')->textInput(['maxlength' => true]) ?>
 
+    <?= $form->field($model, 'targets')->textInput() ?>
+
+    <?= $form->field($model, 'environment')->textInput() ?>
+
     <div class="form-group">
         <?= Html::submitButton($model->isNewRecord ? 'Create' : 'Update', ['class' => $model->isNewRecord ? 'btn btn-success' : 'btn btn-primary']) ?>
     </div>

--- a/application/frontend/views/release-admin/view.php
+++ b/application/frontend/views/release-admin/view.php
@@ -48,6 +48,8 @@ $this->params['breadcrumbs'][] = $this->title;
                 'value' =>  Html::a($model->build_guid, $model->codebuild_url),
             ],
             'promote_from',
+            'targets',
+            'environment'
         ],
     ]) ?>
 

--- a/application/tests/unit/common/components/CodeBuildTest.php
+++ b/application/tests/unit/common/components/CodeBuildTest.php
@@ -240,6 +240,18 @@ class CodeBuildTest extends UnitTestBase
                 case 'PROMOTE_FROM':
                     $promoteFrom = $environmentVariable['value'];
                     break;
+                case 'TARGETS':
+                    $targets = $environmentVariable['value'];
+                    break;
+                case 'SCRIPT_S3':
+                    $scriptS3 = $environmentVariable['value'];
+                    break;
+                case 'VAR1':
+                    $var1 = $environmentVariable['value'];
+                    break;
+                case 'VAR2' :
+                    $var2 = $environmentVariable['value'];
+                    break;
                 default:
                     $this->assertEquals("Unknown", $environmentVariable['name'], " *** Unexpected variable definition");     
             }
@@ -251,6 +263,10 @@ class CodeBuildTest extends UnitTestBase
         $this->assertEquals("s3://sil-appbuilder-artifacts/testing/jobs/build_scriptureappbuilder_22/12", $artifactDir, " *** Wrong artifact directory");
         $this->assertEquals("alpha", $channel, " *** Bad channel");
         $this->assertEquals("", $promoteFrom, " *** Wrong promote from value");
+        $this->assertEquals("google-play", $targets, " *** Wrong target");
+        $this->assertEquals("s3://sil-prd-aps-projects/default", $scriptS3, " *** Wrong S3 Script");
+        $this->assertEquals("VALUE1", $var1, " *** Wrong test var1 value");
+        $this->assertEquals("VALUE2", $var2, " *** Wrong test var2 value");
     }
     public function testAddEnvironmentVariables()
     {
@@ -271,7 +287,7 @@ class CodeBuildTest extends UnitTestBase
         MockCodeBuildClient::clearGlobals();
         $codebuild = new CodeBuild();
         $method = $this->getPrivateMethod('common\components\CodeBuild', 'addEnvironmentToArray');
-        $returnedEnvironment = $method->invokeArgs($codebuild, array( $environmentArray, $build));
+        $returnedEnvironment = $method->invokeArgs($codebuild, array( $environmentArray, $build->environment));
         $this->assertEquals(4, sizeof($returnedEnvironment), "*** Wrong array size");
         $env0 = $returnedEnvironment[0];
         $env2 = $returnedEnvironment[2];

--- a/application/tests/unit/common/components/CodeBuildTest.php
+++ b/application/tests/unit/common/components/CodeBuildTest.php
@@ -158,6 +158,18 @@ class CodeBuildTest extends UnitTestBase
                 case 'PROJECT_S3':
                     $projectS3 = $environmentVariable['value'];
                     break;
+                case 'TARGETS':
+                    $targets = $environmentVariable['value'];
+                    break;
+                case 'SCRIPT_S3':
+                    $scriptS3 = $environmentVariable['value'];
+                    break;
+                case 'VAR1':
+                    $var1 = $environmentVariable['value'];
+                    break;
+                case 'VAR2' :
+                    $var2 = $environmentVariable['value'];
+                    break;
                 default:
                     $this->assertEquals("Unknown", $environmentVariable['name'], " *** Unexpected variable definition");
             }
@@ -169,6 +181,10 @@ class CodeBuildTest extends UnitTestBase
         $this->assertEquals("1", $versionCode, " *** Wrong version code");
         $this->assertEquals("scripture-app-builder", $scriptPath, " *** Bad script path");
         $this->assertEquals($url, $projectS3, " *** Wrong project name");
+        $this->assertEquals('play-listing', $targets, " *** Wrong target");
+        $this->assertEquals('s3://sil-prd-aps-projects/default', $scriptS3, " ***Wrong S3 Script");
+        $this->assertEquals("VALUE1", $var1, " *** Wrong test var1 value");
+        $this->assertEquals("VALUE2", $var2, " *** Wrong test var2 value");
     }
     public function testGetSourceLocation()
     {
@@ -235,5 +251,36 @@ class CodeBuildTest extends UnitTestBase
         $this->assertEquals("s3://sil-appbuilder-artifacts/testing/jobs/build_scriptureappbuilder_22/12", $artifactDir, " *** Wrong artifact directory");
         $this->assertEquals("alpha", $channel, " *** Bad channel");
         $this->assertEquals("", $promoteFrom, " *** Wrong promote from value");
+    }
+    public function testAddEnvironmentVariables()
+    {
+        $this->setContainerObjects();
+        $build = Build::findOne(['id' => 12]);
+        $buildNumber = '1';
+        $buildPath = 'build';
+        $environmentArray = [
+            [
+                'name' => 'BUILD_NUMBER',
+                'value' => $buildNumber,
+            ],
+            [
+                'name' => 'APP_BUILDER_SCRIPT_PATH',
+                'value' => $buildPath,
+            ],
+        ];
+        MockCodeBuildClient::clearGlobals();
+        $codebuild = new CodeBuild();
+        $method = $this->getPrivateMethod('common\components\CodeBuild', 'addEnvironmentToArray');
+        $returnedEnvironment = $method->invokeArgs($codebuild, array( $environmentArray, $build));
+        $this->assertEquals(4, sizeof($returnedEnvironment), "*** Wrong array size");
+        $env0 = $returnedEnvironment[0];
+        $env2 = $returnedEnvironment[2];
+        $env3 = $returnedEnvironment[3];
+        $this->assertEquals("BUILD_NUMBER", $env0['name'], ' *** Wrong name for 1st env var');
+        $this->assertEquals("1", $env0['value'], " *** Wrong value for first env var");
+        $this->assertEquals("VAR1", $env2['name'], " *** Wrong name for 3rd env var");
+        $this->assertEquals("VALUE1", $env2['value'], " *** Wrong value for 3rd env var");
+        $this->assertEquals("VAR2", $env3['name'], " *** Wrong name for 4th env var");
+        $this->assertEquals("VALUE2", $env3['value'], " *** Wrong value for 4th env var");
     }
 }

--- a/application/tests/unit/console/components/ManageBuildActionTest.php
+++ b/application/tests/unit/console/components/ManageBuildActionTest.php
@@ -54,11 +54,11 @@ class ManageBuildActionTest extends UnitTestBase
         $this->setContainerObjects();
         $cronController = new MockCronController();
         $buildsAction = new ManageBuildsAction($cronController);
-        $method = $this->getPrivateMethod('console\components\ManageBuildsAction', 'getNextVersionCode');
+        $method = $this->getPrivateMethod('console\components\ManageBuildsAction', 'getVersionCode');
         $build = Build::findOne(['id' => 13]);
         $job = $build->job;
         $versionCode = $method->invokeArgs($buildsAction, array( $job, $build));
-        $this->assertEquals(3, $versionCode, " *** version code should max for completed job +1"); 
+        $this->assertEquals(2, $versionCode, " *** version code should max for completed job"); 
     }
     public function testNextVersionWithSet()
     {
@@ -69,11 +69,11 @@ class ManageBuildActionTest extends UnitTestBase
         $job->existing_version_code = $initialVC;
         $job->save();
         $buildsAction = new ManageBuildsAction($cronController);
-        $method = $this->getPrivateMethod('console\components\ManageBuildsAction', 'getNextVersionCode');
+        $method = $this->getPrivateMethod('console\components\ManageBuildsAction', 'getVersionCode');
         $build = Build::findOne(['id' => 13]);
         $job2 = $build->job;
         $versionCode = $method->invokeArgs($buildsAction, array( $job2, $build));
-        $this->assertEquals(11, $versionCode, " *** version code should be initial version code +1");
+        $this->assertEquals(10, $versionCode, " *** version code should be initial version code");
     }    /**
      * The start building tests test the method in ActionCommon
      */

--- a/application/tests/unit/fixtures/data/common/models/Build.php
+++ b/application/tests/unit/fixtures/data/common/models/Build.php
@@ -30,6 +30,8 @@ return [
         'updated' => Utils::getDatetime(),
         'channel' => 'unpublished',
         'version_code' => 2,
+        'targets' => 'apk play-listing',
+        'environment' => '{"VAR1":"VALUE1","VAR2":"VALUE2"}'
     ],
     'build3' => [
         'id' => 13,
@@ -282,6 +284,8 @@ return [
         'updated' => Utils::getDatetime(),
         'channel' => 'unpublished',
         'version_code' => NULL,
+        'targets' => 'play-listing',
+        'environment' => '{"VAR1":"VALUE1","VAR2":"VALUE2"}'
     ],
 
 ];

--- a/application/tests/unit/fixtures/data/common/models/Release.php
+++ b/application/tests/unit/fixtures/data/common/models/Release.php
@@ -41,6 +41,8 @@ return [
         'title' => NULL,
         'defaultLanguage' => NULL,
         'build_guid' => 'f16d4385-5579-4139-8c1e-a3937e88b25',
+        'targets' => 'google-play',
+        'environment' => '{"VAR1":"VALUE1","VAR2":"VALUE2"}'
     ],
     'release4' => [
         'id' => 13,

--- a/application/tests/unit/frontend/components/JobControllerUtilsTest.php
+++ b/application/tests/unit/frontend/components/JobControllerUtilsTest.php
@@ -43,7 +43,7 @@ class JobControllerUtilsTest extends UnitTestBase
     public function testPublishBuild()
     {
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('23', '21', 'alpha', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('23', '21', 'alpha', 'test', 'en', "google-play", "");
         $this->assertEquals('21', $release->build_id, "*** Build id in published release incorrect");
         $this->assertEquals('alpha', $release->channel, "*** Channel in published release incorrect");
         $this->assertNull($release->promote_from, "*** Promote from for unpublished build is not null");
@@ -51,7 +51,7 @@ class JobControllerUtilsTest extends UnitTestBase
     public function testPublishBuildAlphaToBeta()
     {
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('25', '24', 'beta', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('25', '24', 'beta', 'test', 'en', "google-play", "");
         $this->assertEquals('24', $release->build_id, "*** Build id in published release incorrect");
         $this->assertEquals('beta', $release->channel, "*** Channel in published release incorrect");
         $this->assertEquals('alpha', $release->promote_from, "*** Promote From incorrect");
@@ -59,7 +59,7 @@ class JobControllerUtilsTest extends UnitTestBase
     public function testPublishBuildAlphaToProduction()
     {
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('25', '24', 'production', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('25', '24', 'production', 'test', 'en', "google-play", "");
         $this->assertEquals('24', $release->build_id, "*** Build id in published release incorrect");
         $this->assertEquals('production', $release->channel, "*** Channel in published release incorrect");
         $this->assertEquals('alpha', $release->promote_from, "*** Promote From incorrect");
@@ -68,19 +68,19 @@ class JobControllerUtilsTest extends UnitTestBase
     {
         $this->setExpectedException('yii\\web\\ServerErrorHttpException');
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('24', '25', 'alpha', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('24', '25', 'alpha', 'test', 'en', "google-play", "");
     }
     public function testPublishBuildBetaToBeta()
     {
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('24', '25', 'beta', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('24', '25', 'beta', 'test', 'en', "google-play", "");
         $this->assertEquals('beta', $release->channel, "*** Channel in published release incorrect");
         $this->assertNull($release->promote_from);
     }
     public function testPublishBuildBetaToProduction()
     {
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('24', '25', 'production', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('24', '25', 'production', 'test', 'en', 'google-play', '');
         $this->assertEquals('production', $release->channel, "*** Channel in published release incorrect");
         $this->assertEquals('beta', $release->promote_from, "*** Promote From incorrect");
     }
@@ -88,13 +88,13 @@ class JobControllerUtilsTest extends UnitTestBase
     {
         $this->setExpectedException('yii\\web\\NotFoundHttpException');
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('87', '21', 'alpha', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('87', '21', 'alpha', 'test', 'en', 'google-play', '');
     }
     public function testPublishBuildExceptionBadUrl()
     {
         $this->setExpectedException('yii\\web\\ServerErrorHttpException');
         $jobControllerUtils = new JobControllerUtils();
-        $release = $jobControllerUtils->publishBuild('22', '11', 'alpha', 'test', 'en');
+        $release = $jobControllerUtils->publishBuild('22', '11', 'alpha', 'test', 'en', 'google-play', '');
     }
     public function testVerifyChannel()
     {


### PR DESCRIPTION
Move most of the build and release logic to separate build scripts
Allow user to designate targets
Implement current build and publish functions in script and allow user targets to be
implemented in user supplied gradle scripts in their own project folder