### PR TITLE
Change how app-builders version is determined

### DIFF
--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -109,7 +109,7 @@ prepare_appbuilder_project() {
   if [[ "${BUILD_MANAGE_VERSION_NAME}" == "0" ]]; then
       VERSION_NAME=${APPDEF_VERSION_NAME}
   else
-      VERSION_NAME=$(dpkg -s "${APP_BUILDER_SCRIPT_PATH}" | grep 'Version' | awk -F '[ +]' '{print $2}')
+      VERSION_NAME=$("${APP_BUILDER_SCRIPT_PATH}" -? | grep 'Version' | awk -F '[ +]' '{print $2}')
   fi
 
   APPDEF_VERSION_CODE=$(grep "version code=" build.appDef|awk -F"\"" '{print $2}')


### PR DESCRIPTION
* when app-builders were combined into a single package, dpkg could
  not be used to get the version.  use -? option to get version.