### PR TITLE
Supply requires version code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 start: app
 
-test: testSh composer rmTestDb upTestDb yiimigratetestDb rmTestDb
+test: clean testSh composer rmTestDb upTestDb yiimigratetestDb rmTestDb
 	docker-compose run --rm cli bash -c 'MYSQL_HOST=testDb MYSQL_DATABASE=test ./vendor/bin/codecept --debug run unit'
 
 testSh:

--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -7,6 +7,8 @@ publish_google_play() {
   cd "$ARTIFACTS_DIR" || exit 1
   SUPPLY_PACKAGE_NAME="$(cat package_name.txt)"
   export SUPPLY_PACKAGE_NAME
+  SUPPLY_VERSION_CODE="$(cat version_code.txt)"
+  export SUPPLY_VERSION_CODE
   export SUPPLY_METADATA_PATH="play-listing"
 
   if [[ -z "${PUBLISH_NO_APK}" ]]; then


### PR DESCRIPTION
fastlane.tools implementation of supply has changed to support Google Play Store API v3. When republishing, fastlane supply now needs the VERSION_CODE specified.