### PR TITLE
Support publishing multiple APKs

### DIFF
--- a/application/console/migrations/m200616_193900_alter_multiple_apks.php
+++ b/application/console/migrations/m200616_193900_alter_multiple_apks.php
@@ -1,0 +1,19 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m200616_193900_alter_multiple_apks
+ */
+class m200616_193900_alter_multiple_apks extends Migration
+{
+    public function up()
+    {
+        $this->alterColumn("{{build}}", "artifact_files", "varchar(4096) null");
+    }
+
+    public function down()
+    {
+        $this->alterColumn("{{build}}", "artifact_files", Schema::TYPE_STRING. " null");
+    }
+}

--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -216,12 +216,6 @@ prepare_appbuilder_project() {
     echo "ERROR: Project appDef or project data not found"
     exit 3
   fi
-
-  MULTIPLE_APKS=$(xmllint --xpath "string(/app-definition/multiple-apks/@value)" build.appDef)
-  if [[ "${MULTIPLE_APKS}" == "true" ]]; then
-      echo "ERROR: multiple-apks not supported yet"
-      exit 4
-  fi
   
   PUBLISH_PROPERTIES="build_data/publish/properties.json"
   if [[ -f "${PUBLISH_PROPERTIES}" ]]; then

--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -13,12 +13,13 @@ publish_google_play() {
   export SUPPLY_METADATA_PATH="play-listing"
 
   if [[ -z "${PUBLISH_NO_APK}" ]]; then
-    echo "Publishing APK"
     if [[ "${#APK_FILES[@]}" -gt 1 ]]; then
-      echo "Too many APK files: ${#APK_FILES[@]}"
-      exit 2
+      echo "Publishing APKs"
+      export SUPPLY_APK_PATHS="${APK_FILES[*]}"
+    else
+      echo "Publishing APK"
+      export SUPPLY_APK="${APK_FILES[0]}"
     fi
-    export SUPPLY_APK="${APK_FILES[0]}"
   else
     echo "Not publishing APK"
     export SUPPLY_SKIP_UPLOAD_APK=true

--- a/application/frontend/views/build-admin/view.php
+++ b/application/frontend/views/build-admin/view.php
@@ -10,40 +10,12 @@ $this->title = $model->id;
 $this->params['breadcrumbs'][] = ['label' => 'Builds', 'url' => ['index']];
 $this->params['breadcrumbs'][] = $this->title;
 
-$value = "";
-if (strpos($model->targets, "apk") !== false) {
-    $value = $value .
-        Html::a("apk", $model->apk()) . ", " .
-        Html::a("about", $model->about()) . ", " . $value;
+$artifacts = $model->artifacts();
+$entries = array();
+foreach ($artifacts as $key => $artifact) {
+    array_push($entries, Html::a($key, $artifact));
 }
-
-if (strpos($model->targets, "play-listing") !== false) {
-    $value = $value .
-        Html::a("play-listing", $model->playListing()) . ", " .
-        Html::a("play-listing-manifest", $model->playListingManifest()) . ", " .
-        Html::a("version_code", $model->versionCode()) . ", " .
-        Html::a("version", $model->version()) . ", " .
-        Html::a("package_name", $model->packageName()) . ", " .
-        Html::a("whats_new", $model->whatsNew()) . ", ";
-}
-
-if (strpos($model->targets, "html") !== false) {
-    $value = $value . $value = Htm::a("html", $model->html()) . ", ";
-}
-
-if (strpos($model->targets, "pwa") !== false) {
-    $value = $value = Html::a("pwa", $model->pwa()) . ", ";
-}
-
-$value = $value .
-    Html::a("cloudWatch", $model->cloudWatch()) . ", " .
-    Html::a("consoleText", $model->consoleText());
-
-$publishProperties = $model->publishProperties();
-if (!empty($publishProperties)) {
-    $value = $value . ", " .
-    Html::a("publishProperties", $publishProperties);
-}
+$artifacts_value = join(", ", $entries);
 
 ?>
 <div class="build-view">
@@ -85,7 +57,7 @@ if (!empty($publishProperties)) {
             [
                 'attribute' => 'artifacts',
                 'format'=>'html',
-                'value'=> $value
+                'value'=> $artifacts_value
             ],
             'created',
             'updated',


### PR DESCRIPTION
- Make table=build column=artifact_files large enough to handle more files
- If multiple apks, then report back with artifactType=`arch-apk`
- If multiple apks, use SUPPLY_APK_PATHS instead of SUPPLY_APK during publish
- Handle multiple apks in the build view
- Remove the temporary block on multiple apks