### PR TITLE
Change how shellcheck is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,6 @@ RUN chown -R www-data:www-data \
 # Install/cleanup composer dependencies
 RUN composer install --prefer-dist --no-interaction --no-dev --optimize-autoloader
 
-# Install shellcheck for validating shell scripts
-RUN apt-get update && apt-get install -y \
-    shellcheck \
-&& rm -rf /var/lib/apt/lists/*
-
 EXPOSE 80
 ENTRYPOINT ["s3-expand"]
 CMD ["/data/run.sh"]

--- a/application/run-tests.sh
+++ b/application/run-tests.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 # Run shell tests
+scversion="stable" # or "v0.4.7", or "latest"
+curl -s -L --output - "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
+cp "shellcheck-${scversion}/shellcheck" /usr/bin/
+shellcheck --version
 shellcheck /data/console/views/cron/scripts/upload/default/*.sh || exit 1
 
 # Run database migrations


### PR DESCRIPTION
* The version of shellcheck installed with the OS is WAAAY out
  of date.
* Shellcheck only needs to be installed when running tests. So
  Remove from Dockerfile and install latest version when running
  tests.