### PR TITLE
Run "fastlane env" during Google Play Publish

### DIFF
--- a/application/console/views/cron/scripts/upload/default/publish.sh
+++ b/application/console/views/cron/scripts/upload/default/publish.sh
@@ -9,6 +9,7 @@ export PATH="$HOME/.rbenv/bin:$PATH"
 eval "$(rbenv init -)"
 
 publish_google_play() {
+  fastlane env
   echo "OUTPUT_DIR=${OUTPUT_DIR}"
   export SUPPLY_JSON_KEY="${SECRETS_DIR}/google_play_store/${PUBLISHER}/playstore_api.json"
   cd "$ARTIFACTS_DIR" || exit 1


### PR DESCRIPTION
If something goes wrong during a Google Play Publish, we often will need the output from running `fastlane env` to be able to report an bugs.  Let's include it in the builds.