### PR TITLE
Fix build breaks when regex chars in project name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
         id: branch
         run: |
           if [[ "${GITHUB_HEAD_REF}" != "" ]]; then BRANCH="${GITHUB_HEAD_REF}"; else BRANCH="${GITHUB_REF_NAME}"; fi
-          case $BRANCH in develop) DOCKER_TAG="staging" ;; master) DOCKER_TAG="production" ;; *) DOCKER_TAG=$BRANCH ;; esac
+          case $BRANCH in develop) DOCKER_TAG="staging" ;; master) DOCKER_TAG="production" ;; *) DOCKER_TAG="${BRANCH//\//-}" ;; esac
           echo "::set-output name=DockerTag::${DOCKER_TAG}"
 
       - name: Build and push Docker images

--- a/application/console/views/cron/scripts/upload/default/build.sh
+++ b/application/console/views/cron/scripts/upload/default/build.sh
@@ -362,7 +362,7 @@ prepare_appbuilder_project() {
   fi
 
   PROJ_NAME=$(basename -- *.appDef .appDef)
-  PROJ_DIR=$(find . | grep -i "${PROJ_NAME}_data$" | head -n1)
+  PROJ_DIR=$(find . | grep -i -F "${PROJ_NAME}_data" | head -n1)
   if [[ -f "${PROJ_NAME}.appDef" && -d "${PROJ_DIR}" ]]; then
     echo "Moving ${PROJ_NAME}.appDef and ${PROJ_DIR}"
     mv "${PROJ_NAME}.appDef" build.appDef


### PR DESCRIPTION
* Dan had project names with brackets [] or braces () and we
  were using the project name in a grep to match the directory name
  with the project name. Change the grep to treat the search string
  as a fixed string so that these regex chars can be using in the
  project name.