### PR TITLE
Fix filename returned from Build:artifactType for notify.json

### DIFF
--- a/application/common/models/Build.php
+++ b/application/common/models/Build.php
@@ -428,7 +428,7 @@ class Build extends BuildBase implements Linkable, ArtifactsProvider
             $file = "asset-package/preview.html";
         } else if (preg_match("/asset-package\/notify\.json$/", $key)) {
             $type = self::ARTIFACT_ASSET_NOTIFY;
-            $file = "asset-package/preview.html";
+            $file = "asset-package/notify.json";
         } else if (preg_match("/play-listing\/index\.html$/", $key)) {
             $type = self::ARTIFACT_PLAY_LISTING;
             $file = "play-listing/index.html";


### PR DESCRIPTION
Fix for potential copy-paste error I stumbled across