### PR TITLE
Port unfinished channel verification feature from BE 1

### DIFF
--- a/src/lib/server/models/build.ts
+++ b/src/lib/server/models/build.ts
@@ -19,11 +19,33 @@ export namespace Build {
     Aborted = 'ABORTED'
   }
 
-  export enum Channel {
-    Unpublished = 'unpublished',
-    Alpha = 'alpha',
-    Beta = 'beta',
-    Production = 'production'
+  export const Channels = {
+    Unpublished: 'unpublished',
+    Alpha: 'alpha',
+    Beta: 'beta',
+    Production: 'production'
+  } as const;
+  export type Channel = (typeof Channels)[keyof typeof Channels];
+
+  const transitions = {
+    [Channels.Unpublished]: [Channels.Alpha, Channels.Beta, Channels.Production],
+    [Channels.Alpha]: [Channels.Alpha, Channels.Beta, Channels.Production],
+    [Channels.Beta]: [Channels.Beta, Channels.Production],
+    [Channels.Production]: [Channels.Production]
+  } as const as Readonly<Record<Channel, Channel[]>>;
+
+  type BuildForChannel = Prisma.buildGetPayload<{
+    select: { channel: true };
+  }>;
+
+  export function verifyChannel(target: Channel, build: BuildForChannel): boolean {
+    return (
+      // if unpublished OK
+      !build.channel ||
+      build.channel === Channels.Unpublished ||
+      // check if transition valid
+      transitions[build.channel as Channel]?.includes(target)
+    );
   }
 
   export enum Artifact {

--- a/src/routes/(api)/job/[jobId=idNumber]/build/[buildId=idNumber]/+server.ts
+++ b/src/routes/(api)/job/[jobId=idNumber]/build/[buildId=idNumber]/+server.ts
@@ -68,7 +68,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const runningRelease = await prisma.release.findFirst({
     where: {
       build_id: Number(params.buildId),
-      status: { in: [Release.Status.Accepted, Release.Status.Active] }
+      status: { in: [Release.Status.Initialized, Release.Status.Accepted, Release.Status.Active] }
     }
   });
   if (runningRelease) {
@@ -89,7 +89,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   if (!build) return ErrorResponse(404, 'Build not found');
 
   if (build.status !== Build.Status.Completed)
-    return ErrorResponse(409, `Build is incomplete. Current Status: ${build.result}`);
+    return ErrorResponse(409, `Build is incomplete. Current Status: ${build.status}`);
 
   if (build.result !== Build.Result.Success)
     return ErrorResponse(403, `Build was unsuccessful. Result: ${build.result}`);

--- a/src/routes/(api)/job/[jobId=idNumber]/build/[buildId=idNumber]/+server.ts
+++ b/src/routes/(api)/job/[jobId=idNumber]/build/[buildId=idNumber]/+server.ts
@@ -66,7 +66,10 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const parsed = v.safeParse(releaseSchema, await request.json());
   if (!parsed.success) return ErrorResponse(400, JSON.stringify(v.flatten(parsed.issues)));
   const runningRelease = await prisma.release.findFirst({
-    where: { build_id: Number(params.buildId), status: { in: ['accepted', 'active'] } }
+    where: {
+      build_id: Number(params.buildId),
+      status: { in: [Release.Status.Accepted, Release.Status.Active] }
+    }
   });
   if (runningRelease) {
     return ErrorResponse(500, 'Release already in progress');
@@ -77,7 +80,7 @@ export const PUT: RequestHandler = async ({ request, params }) => {
       id: true,
       build: {
         where: { id: Number(params.buildId) },
-        select: { id: true, version_code: true }
+        select: { id: true, channel: true, status: true, result: true }
       }
     }
   });
@@ -85,7 +88,15 @@ export const PUT: RequestHandler = async ({ request, params }) => {
   const build = job.build.at(0);
   if (!build) return ErrorResponse(404, 'Build not found');
 
-  // TODO verify channel
+  if (build.status !== Build.Status.Completed)
+    return ErrorResponse(409, `Build is incomplete. Current Status: ${build.result}`);
+
+  if (build.result !== Build.Result.Success)
+    return ErrorResponse(403, `Build was unsuccessful. Result: ${build.result}`);
+
+  if (!Build.verifyChannel(parsed.output.channel as Build.Channel, build))
+    return ErrorResponse(400, `Cannot promote from ${build.channel} to ${parsed.output.channel}`);
+
   const release = await prisma.release.create({
     data: {
       ...parsed.output,


### PR DESCRIPTION
Valid target channels: `alpha` -> `beta` -> `production`

A build may always be released to a channel equal to or greater than its current channel.

Once we are ready, corresponding changes will need to be made in scriptoria to support release channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Implemented comprehensive validation for build promotions, including channel transition verification
  * Builds now require successful completion and valid result status before promotion is allowed
  * Invalid promotion requests return specific error codes for improved error diagnostics

* **Chores**
  * Refactored internal build channel type system for better type safety

<!-- end of auto-generated comment: release notes by coderabbit.ai -->